### PR TITLE
API Gateway Compatible API Key

### DIFF
--- a/packages/temdb-client/src/temdb/client/_client.py
+++ b/packages/temdb-client/src/temdb/client/_client.py
@@ -55,6 +55,7 @@ class AsyncTEMdbClient:
         headers = {}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
+            headers["X-API-Key"] = api_key
 
         self._http_client = httpx.AsyncClient(
             base_url=self.api_url,


### PR DESCRIPTION
The client was originally set up to use an `Authorization: Bearer {key}` format for the API key. However, AWS API Gateway uses the `X-API-Key: {key}` format. To make both compatible the provided API key is now sent in both headers.