### PR TITLE
Cleaning up the acquisition task status tracking system

### DIFF
--- a/packages/temdb-client/src/temdb/client/resources/sync_wrappers/task.py
+++ b/packages/temdb-client/src/temdb/client/resources/sync_wrappers/task.py
@@ -6,7 +6,6 @@ from temdb.models import (
     AcquisitionResponse,
     AcquisitionTaskCreate,
     AcquisitionTaskResponse,
-    AcquisitionTaskStatus,
     AcquisitionTaskUpdate,
 )
 
@@ -23,11 +22,12 @@ class SyncAcquisitionTaskResourceWrapper:
         self,
         skip: int = 0,
         limit: int = 100,
-        status: AcquisitionTaskStatus | None = None,
         specimen_id: str | None = None,
         block_id: str | None = None,
         roi_id: int | None = None,
         task_type: str | None = None,
+        skip_destroyed: bool = True,
+        skip_completed: bool = True,
         **kwargs: Any,
     ) -> list[AcquisitionTaskResponse]:
         """List acquisition tasks."""
@@ -35,11 +35,12 @@ class SyncAcquisitionTaskResourceWrapper:
             self._async_resource.list(
                 skip=skip,
                 limit=limit,
-                status=status,
                 specimen_id=specimen_id,
                 block_id=block_id,
                 roi_id=roi_id,
                 task_type=task_type,
+                skip_destroyed=skip_destroyed,
+                skip_completed=skip_completed,
                 **kwargs,
             )
         )
@@ -65,10 +66,6 @@ class SyncAcquisitionTaskResourceWrapper:
     ) -> builtins.list[AcquisitionResponse]:
         """List acquisitions related to a specific task."""
         return asyncio.run(self._async_resource.list_related_acquisitions(task_id, skip=skip, limit=limit))
-
-    def update_status(self, task_id: str, status: AcquisitionTaskStatus) -> AcquisitionTaskResponse:
-        """Update the status of an acquisition task."""
-        return asyncio.run(self._async_resource.update_status(task_id, status))
 
     def create_batch(self, tasks_data: builtins.list[AcquisitionTaskCreate]) -> builtins.list[AcquisitionTaskResponse]:
         """Create a batch of acquisition tasks."""

--- a/packages/temdb-client/src/temdb/client/resources/task.py
+++ b/packages/temdb-client/src/temdb/client/resources/task.py
@@ -5,7 +5,6 @@ from temdb.models import (
     AcquisitionResponse,
     AcquisitionTaskCreate,
     AcquisitionTaskResponse,
-    AcquisitionTaskStatus,
     AcquisitionTaskUpdate,
 )
 
@@ -19,22 +18,24 @@ class AcquisitionTaskResource(BaseResource):
         self,
         skip: int = 0,
         limit: int = 100,
-        status: AcquisitionTaskStatus | None = None,
         specimen_id: str | None = None,
         block_id: str | None = None,
         roi_id: int | None = None,
         task_type: str | None = None,
+        skip_destroyed: bool = True,
+        skip_completed: bool = True,
         **kwargs: Any,
     ) -> list[AcquisitionTaskResponse]:
         """List acquisition tasks with optional filtering and pagination."""
         params = {
             "skip": skip,
             "limit": limit,
-            "status": status.value if status else None,
             "specimen_id": specimen_id,
             "block_id": block_id,
             "roi_id": roi_id,
             "task_type": task_type,
+            "skip_destroyed": skip_destroyed,
+            "skip_completed": skip_completed,
         }
         params = {k: v for k, v in params.items() if v is not None}
         params.update(kwargs)
@@ -83,13 +84,6 @@ class AcquisitionTaskResource(BaseResource):
             if isinstance(response_data, list)
             else []
         )
-
-    async def update_status(self, task_id: str, status: AcquisitionTaskStatus) -> AcquisitionTaskResponse:
-        """Update the status of an acquisition task."""
-        endpoint = f"acquisition-tasks/{task_id}/status"
-        status_payload = {"status": status.value}
-        response_data = await self._post(endpoint, data=status_payload)
-        return AcquisitionTaskResponse.model_validate(response_data)
 
     async def create_batch(
         self, tasks_data: builtins.list[AcquisitionTaskCreate]

--- a/packages/temdb-models/src/temdb/models/__init__.py
+++ b/packages/temdb-models/src/temdb/models/__init__.py
@@ -25,7 +25,6 @@ from temdb.models.cutting_session import (
 )
 from temdb.models.enums import (
     AcquisitionStatus,
-    AcquisitionTaskStatus,
     SectionQuality,
 )
 from temdb.models.error import APIErrorResponse
@@ -82,7 +81,6 @@ from temdb.models.tile import (
 __all__ = [
     # Enums
     "AcquisitionStatus",
-    "AcquisitionTaskStatus",
     "SectionQuality",
     # Tile
     "Matcher",

--- a/packages/temdb-models/src/temdb/models/acquisition.py
+++ b/packages/temdb-models/src/temdb/models/acquisition.py
@@ -97,7 +97,7 @@ class AcquisitionCreate(AcquisitionBase):
     acquisition_settings: AcquisitionParams = Field(..., description="Acquisition settings of acquisition")
     tilt_angle: float = Field(..., description="Tilt angle of acquisition in degrees")
     lens_correction: bool = Field(..., description="Whether this acquisition is a lens correction calibration")
-    status: AcquisitionStatus = Field(default=AcquisitionStatus.IMAGING, description="Status of acquisition")
+    status: AcquisitionStatus = Field(default=AcquisitionStatus.QC_PENDING, description="Status of acquisition")
     start_time: datetime | None = Field(None, description="Start time of acquisition (defaults to now if not provided)")
 
 

--- a/packages/temdb-models/src/temdb/models/enums.py
+++ b/packages/temdb-models/src/temdb/models/enums.py
@@ -9,22 +9,11 @@ class SectionQuality(str, Enum):
     EMPTY = "empty"
 
 
-class AcquisitionTaskStatus(str, Enum):
-    PLANNED = "Planned"
-    IN_PROGRESS = "In Progress"
-    COMPLETED = "Completed"
-    FAILED = "Failed"
-    ABORTED = "Aborted"
-
-
 class AcquisitionStatus(str, Enum):
-    IMAGING = "imaging"
-    ACQUIRED = "acquired"
     ABORTED = "aborted"
     QC_FAILED = "failed"
     QC_PASSED = "qc-passed"
     QC_PENDING = "qc-pending"
-    TO_BE_REIMAGED = "to be re-imaged"
 
 
 class MatchPosition(str, Enum):

--- a/packages/temdb-models/src/temdb/models/section.py
+++ b/packages/temdb-models/src/temdb/models/section.py
@@ -66,6 +66,7 @@ class SectionBase(BaseModel):
     )
     barcode: str | None = Field(None, description="Barcode scanned for this section, if any")
     section_metrics: SectionMetrics | None = Field(None, description="Metrics and parameters of the section")
+    destroyed: bool = Field(False, description="Denotes if the section has been destroyed.")
 
 
 class SectionCreate(SectionBase):

--- a/packages/temdb-models/src/temdb/models/task.py
+++ b/packages/temdb-models/src/temdb/models/task.py
@@ -3,8 +3,6 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from temdb.models.enums import AcquisitionTaskStatus
-
 
 class AcquisitionTaskBase(BaseModel):
     """Base acquisition task fields."""
@@ -13,7 +11,6 @@ class AcquisitionTaskBase(BaseModel):
 
     task_type: str | None = Field(None, description="Type of acquisition task")
     version: int | None = Field(None, description="Version number of this task")
-    status: AcquisitionTaskStatus | None = Field(None, description="Status of acquisition task")
     error_message: str | None = Field(None, description="Error message if failed")
     started_at: datetime | None = Field(None, description="When task execution began")
     completed_at: datetime | None = Field(None, description="When task finished (success or failure)")
@@ -30,7 +27,6 @@ class AcquisitionTaskCreate(AcquisitionTaskBase):
     roi_id: str = Field(..., description="ID of region of interest to be acquired")
     task_type: str = Field(default="standard_acquisition", description="Type of acquisition task")
     version: int = Field(default=1, description="Version number of this task")
-    status: AcquisitionTaskStatus = Field(default=AcquisitionTaskStatus.PLANNED)
     tags: list[str] = Field(default_factory=list, description="Tags for filtering")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
@@ -50,7 +46,6 @@ class AcquisitionTaskResponse(AcquisitionTaskBase):
     roi_id: str = Field(..., description="ID of region of interest")
     task_type: str = Field(..., description="Type of acquisition task")
     version: int = Field(..., description="Version number of this task")
-    status: AcquisitionTaskStatus = Field(..., description="Status of acquisition task")
 
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/packages/temdb/src/temdb/server/api/v2/tasks.py
+++ b/packages/temdb/src/temdb/server/api/v2/tasks.py
@@ -3,27 +3,18 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 
 from temdb.models import (
+    AcquisitionStatus,
     AcquisitionTaskCreate,
-    AcquisitionTaskStatus,
     AcquisitionTaskUpdate,
 )
 from temdb.server.database import DatabaseManager
 from temdb.server.dependencies import get_db_manager
-from temdb.server.documents import (
-    AcquisitionDocument as Acquisition,
-)
-from temdb.server.documents import (
-    AcquisitionTaskDocument as AcquisitionTask,
-)
-from temdb.server.documents import (
-    BlockDocument as Block,
-)
-from temdb.server.documents import (
-    ROIDocument as ROI,
-)
-from temdb.server.documents import (
-    SpecimenDocument as Specimen,
-)
+from temdb.server.documents import AcquisitionDocument as Acquisition
+from temdb.server.documents import AcquisitionTaskDocument as AcquisitionTask
+from temdb.server.documents import BlockDocument as Block
+from temdb.server.documents import ROIDocument as ROI
+from temdb.server.documents import SectionDocument as Section
+from temdb.server.documents import SpecimenDocument as Specimen
 
 acquisition_task_api = APIRouter(
     tags=["Acquisition Tasks"],
@@ -37,16 +28,15 @@ acquisition_task_api = APIRouter(
 async def list_tasks(
     skip: int = Query(0, ge=0),
     limit: int = Query(10, ge=1, le=100),
-    status: AcquisitionTaskStatus | None = None,
     specimen_id: str | None = Query(None, description="Filter by human-readable Specimen ID"),
     block_id: str | None = Query(None, description="Filter by human-readable Block ID"),
     roi_id: str | None = Query(None, description="Filter by human-readable ROI ID"),
     task_type: str | None = None,
+    skip_destroyed: bool = Query(True, description="Filter out tasks whose ROI section is destroyed"),
+    skip_completed: bool = Query(True, description="Filter out tasks with QC_PENDING or QC_PASSED acquisitions"),
 ):
     """List acquisition tasks using aggregation to fetch linked data."""
     match_filters = {}
-    if status:
-        match_filters["status"] = status
     if task_type:
         match_filters["task_type"] = task_type
 
@@ -119,6 +109,60 @@ async def list_tasks(
         }
     )
     pipeline.append({"$unwind": {"path": "$roi_data", "preserveNullAndEmptyArrays": True}})
+
+    if skip_destroyed:
+        pipeline.append(
+            {
+                "$lookup": {
+                    "from": Section.Settings.name,
+                    "localField": "roi_data.section_ref.$id",
+                    "foreignField": "_id",
+                    "as": "section_data",
+                }
+            }
+        )
+        pipeline.append({"$unwind": {"path": "$section_data", "preserveNullAndEmptyArrays": True}})
+        pipeline.append({"$match": {"section_data.destroyed": {"$ne": True}}})
+
+    if skip_completed:
+        pipeline.append(
+            {
+                "$lookup": {
+                    "from": Acquisition.Settings.name,
+                    "localField": "_id",
+                    "foreignField": "acquisition_task_ref.$id",
+                    "as": "acquisition_data",
+                }
+            }
+        )
+        pipeline.append(
+            {
+                "$match": {
+                    "$expr": {
+                        "$eq": [
+                            0,
+                            {
+                                "$size": {
+                                    "$filter": {
+                                        "input": "$acquisition_data",
+                                        "as": "acquisition",
+                                        "cond": {
+                                            "$in": [
+                                                "$$acquisition.status",
+                                                [
+                                                    AcquisitionStatus.QC_PENDING.value,
+                                                    AcquisitionStatus.QC_PASSED.value,
+                                                ],
+                                            ]
+                                        },
+                                    }
+                                }
+                            },
+                        ]
+                    }
+                }
+            }
+        )
 
     if skip > 0:
         pipeline.append({"$skip": skip})
@@ -275,19 +319,6 @@ async def get_task_acquisitions(task_id: str, skip: int = Query(0, ge=0), limit:
         .to_list()
     )
     return acquisitions
-
-
-@acquisition_task_api.post("/acquisition-tasks/{task_id}/status", response_model=AcquisitionTask)
-async def update_task_status(task_id: str, status: AcquisitionTaskStatus = Body(..., embed=True)):
-    existing_task = await AcquisitionTask.find_one({"task_id": task_id}, sort=[("version", -1)])
-    if not existing_task:
-        raise HTTPException(404, f"Task ID '{task_id}' not found")
-    if existing_task.status == status:
-        return await AcquisitionTask.get(existing_task.id, fetch_links=True)
-    existing_task.status = status
-    existing_task.updated_at = datetime.now(timezone.utc)
-    await existing_task.save()
-    return await AcquisitionTask.get(existing_task.id, fetch_links=True)
 
 
 @acquisition_task_api.post(

--- a/packages/temdb/src/temdb/server/documents/acquisition.py
+++ b/packages/temdb/src/temdb/server/documents/acquisition.py
@@ -35,7 +35,7 @@ class AcquisitionDocument(Document, AcquisitionBase):
     # Override base fields that are required in document
     hardware_settings: HardwareParams = Field(..., description="Hardware settings of acquisition")
     acquisition_settings: AcquisitionParams = Field(..., description="Acquisition settings of acquisition")
-    status: AcquisitionStatus = Field(default=AcquisitionStatus.IMAGING, description="Status of acquisition")
+    status: AcquisitionStatus = Field(default=AcquisitionStatus.QC_PENDING, description="Status of acquisition")
     start_time: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),
         description="Start time of acquisition",

--- a/packages/temdb/src/temdb/server/documents/section.py
+++ b/packages/temdb/src/temdb/server/documents/section.py
@@ -30,6 +30,7 @@ class SectionDocument(Document, SectionBase):
     block_id: str = Field(..., description="Human-readable ID of the block")
     specimen_id: str = Field(..., description="Human-readable ID of the specimen")
     media_id: str = Field(..., description="Human-readable ID of the substrate")
+    destroyed: bool = Field(False, description="Denotes if the section has been destroyed.")
 
     cutting_session_ref: Link[CuttingSessionDocument] = Field(
         ..., description="Internal Link to the cutting session document"

--- a/packages/temdb/src/temdb/server/documents/task.py
+++ b/packages/temdb/src/temdb/server/documents/task.py
@@ -4,7 +4,7 @@ from beanie import Document, Link
 from pydantic import Field
 from pymongo import ASCENDING, DESCENDING, IndexModel
 
-from temdb.models import AcquisitionTaskBase, AcquisitionTaskStatus
+from temdb.models import AcquisitionTaskBase
 
 from .block import BlockDocument
 from .roi import ROIDocument
@@ -22,7 +22,6 @@ class AcquisitionTaskDocument(Document, AcquisitionTaskBase):
     # Override base fields with defaults for document
     task_type: str = Field("standard_acquisition", description="Type of acquisition task")
     version: int = Field(1, description="Version number of this task")
-    status: AcquisitionTaskStatus = Field(default=AcquisitionTaskStatus.PLANNED)
 
     specimen_ref: Link[SpecimenDocument] = Field(..., description="Internal link to the specimen document")
     block_ref: Link[BlockDocument] = Field(..., description="Internal link to the block document")
@@ -43,7 +42,6 @@ class AcquisitionTaskDocument(Document, AcquisitionTaskBase):
                 [("task_id", ASCENDING), ("version", DESCENDING)],
                 name="task_id_version_index",
             ),
-            IndexModel([("status", ASCENDING)], name="status_index"),
             IndexModel(
                 [("specimen_ref.id", ASCENDING), ("block_ref.id", ASCENDING)],
                 name="specimen_block_ref_index",

--- a/tests/integration/generators.py
+++ b/tests/integration/generators.py
@@ -5,7 +5,6 @@ from faker import Faker
 from temdb.models import (
     AcquisitionParams,
     AcquisitionStatus,
-    AcquisitionTaskStatus,
     HardwareParams,
     SectionQuality,
 )
@@ -174,7 +173,6 @@ def generate_acquisition_task(
         "metadata": ({"priority": fake.random_int(min=1, max=10)} if fake.boolean() else {}),
         "task_type": "standard_acquisition",
         "version": 1,
-        "status": fake.random_element(elements=AcquisitionTaskStatus).value,
         "created_at": fake.past_datetime(start_date="-30d", tzinfo=timezone.utc),
         "updated_at": None,
         "started_at": None,

--- a/tests/models/test_acquisition_models.py
+++ b/tests/models/test_acquisition_models.py
@@ -128,7 +128,7 @@ class TestAcquisitionCreate:
             lens_correction=False,
         )
         assert acq.acquisition_id == "ACQ001"
-        assert acq.status == AcquisitionStatus.IMAGING
+        assert acq.status == AcquisitionStatus.QC_PENDING
 
     def test_required_fields(self):
         with pytest.raises(ValidationError):
@@ -158,7 +158,7 @@ class TestAcquisitionCreate:
             tilt_angle=0.0,
             lens_correction=False,
         )
-        assert acq.status == AcquisitionStatus.IMAGING
+        assert acq.status == AcquisitionStatus.QC_PENDING
 
 
 class TestAcquisitionUpdate:
@@ -169,10 +169,10 @@ class TestAcquisitionUpdate:
 
     def test_partial_update(self):
         update = AcquisitionUpdate(
-            status=AcquisitionStatus.ACQUIRED,
+            status=AcquisitionStatus.QC_PASSED,
             end_time=datetime.now(),
         )
-        assert update.status == AcquisitionStatus.ACQUIRED
+        assert update.status == AcquisitionStatus.QC_PASSED
 
 
 class TestAcquisitionResponse:
@@ -198,7 +198,7 @@ class TestAcquisitionResponse:
                 tile_overlap=0.1,
                 saved_bit_depth=8,
             ),
-            status=AcquisitionStatus.ACQUIRED,
+            status=AcquisitionStatus.QC_PASSED,
             start_time=datetime.now(),
         )
         assert response.acquisition_id == "ACQ001"

--- a/tests/models/test_enums.py
+++ b/tests/models/test_enums.py
@@ -1,4 +1,4 @@
-from temdb.models import AcquisitionStatus, AcquisitionTaskStatus, SectionQuality
+from temdb.models import AcquisitionStatus, SectionQuality
 
 
 class TestSectionQuality:
@@ -17,33 +17,15 @@ class TestSectionQuality:
         assert len(SectionQuality) == 5
 
 
-class TestAcquisitionTaskStatus:
-    def test_all_values_exist(self):
-        assert AcquisitionTaskStatus.PLANNED == "Planned"
-        assert AcquisitionTaskStatus.IN_PROGRESS == "In Progress"
-        assert AcquisitionTaskStatus.COMPLETED == "Completed"
-        assert AcquisitionTaskStatus.FAILED == "Failed"
-        assert AcquisitionTaskStatus.ABORTED == "Aborted"
-
-    def test_is_string_enum(self):
-        assert isinstance(AcquisitionTaskStatus.PLANNED, str)
-
-    def test_all_members_count(self):
-        assert len(AcquisitionTaskStatus) == 5
-
-
 class TestAcquisitionStatus:
     def test_all_values_exist(self):
-        assert AcquisitionStatus.IMAGING == "imaging"
-        assert AcquisitionStatus.ACQUIRED == "acquired"
         assert AcquisitionStatus.ABORTED == "aborted"
         assert AcquisitionStatus.QC_FAILED == "failed"
         assert AcquisitionStatus.QC_PASSED == "qc-passed"
         assert AcquisitionStatus.QC_PENDING == "qc-pending"
-        assert AcquisitionStatus.TO_BE_REIMAGED == "to be re-imaged"
 
     def test_is_string_enum(self):
-        assert isinstance(AcquisitionStatus.IMAGING, str)
+        assert isinstance(AcquisitionStatus.QC_PENDING, str)
 
     def test_all_members_count(self):
-        assert len(AcquisitionStatus) == 7
+        assert len(AcquisitionStatus) == 4

--- a/tests/models/test_task_models.py
+++ b/tests/models/test_task_models.py
@@ -6,7 +6,6 @@ from pydantic import ValidationError
 from temdb.models import (
     AcquisitionTaskCreate,
     AcquisitionTaskResponse,
-    AcquisitionTaskStatus,
     AcquisitionTaskUpdate,
 )
 
@@ -44,11 +43,13 @@ class TestAcquisitionTaskCreate:
 class TestAcquisitionTaskUpdate:
     def test_all_fields_optional(self):
         update = AcquisitionTaskUpdate()
-        assert update.status is None
+        assert update.task_type is None
+        assert update.version is None
+        assert update.error_message is None
 
-    def test_update_status(self):
-        update = AcquisitionTaskUpdate(status=AcquisitionTaskStatus.IN_PROGRESS)
-        assert update.status == AcquisitionTaskStatus.IN_PROGRESS
+    def test_update_metadata(self):
+        update = AcquisitionTaskUpdate(metadata={"notes": "updated"})
+        assert update.metadata == {"notes": "updated"}
 
 
 class TestAcquisitionTaskResponse:
@@ -59,9 +60,8 @@ class TestAcquisitionTaskResponse:
             block_id="BLOCK001",
             roi_id="ROI001",
             task_type="standard_acquisition",
-            status=AcquisitionTaskStatus.PLANNED,
             version=1,
             created_at=datetime.now(),
         )
         assert response.task_id == "TASK001"
-        assert response.status == AcquisitionTaskStatus.PLANNED
+        assert response.task_type == "standard_acquisition"

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -8,7 +8,6 @@ from httpx import ASGITransport, AsyncClient
 from pymongo import AsyncMongoClient
 from testcontainers.mongodb import MongoDbContainer
 
-from temdb.models import AcquisitionStatus, AcquisitionTaskStatus
 from temdb.server.database import DatabaseManager
 from temdb.server.dependencies import get_db_manager
 from temdb.server.documents import (
@@ -206,7 +205,6 @@ async def test_acquisition_task(
         roi_ref=test_roi.id,
         task_type="standard_acquisition",
         version=1,
-        status=AcquisitionTaskStatus.PLANNED,
         created_at=datetime.now(timezone.utc),
     )
     await acquisition_task.insert()
@@ -244,7 +242,6 @@ async def test_acquisition(
             "tile_overlap": 0.1,
             "saved_bit_depth": 8,
         },
-        status=AcquisitionStatus.IMAGING,
         start_time=datetime.now(timezone.utc),
     )
     await acquisition.insert()

--- a/tests/server/test_acquisition_api.py
+++ b/tests/server/test_acquisition_api.py
@@ -47,10 +47,9 @@ async def test_list_acquisitions_filtered(
     assert any(a["acquisition_id"] == test_acquisition.acquisition_id for a in resp_task.json()["acquisitions"])
 
     # Filter by status
-    resp_status = await async_client.get(f"/api/v2/acquisitions?status={AcquisitionStatus.IMAGING.value}")
+    resp_status = await async_client.get(f"/api/v2/acquisitions?status={AcquisitionStatus.QC_PENDING.value}")
     assert resp_status.status_code == 200
-    # Assumes test_acquisition fixture has IMAGING status
-    assert all(a["status"] == AcquisitionStatus.IMAGING.value for a in resp_status.json()["acquisitions"])
+    assert all(a["status"] == AcquisitionStatus.QC_PENDING.value for a in resp_status.json()["acquisitions"])
 
 
 @pytest.mark.asyncio
@@ -80,7 +79,7 @@ async def test_create_acquisition(async_client: AsyncClient, test_specimen, test
         },
         "tilt_angle": 5.0,
         "lens_correction": False,
-        "status": AcquisitionStatus.IMAGING.value,
+        "status": AcquisitionStatus.QC_PENDING.value,
     }
     response = await async_client.post("/api/v2/acquisitions", json=acquisition_data)
     assert response.status_code == 201
@@ -156,11 +155,11 @@ async def test_get_acquisition_not_found(async_client: AsyncClient):
 @pytest.mark.asyncio
 async def test_update_acquisition(async_client: AsyncClient, test_acquisition):
     """Test updating an acquisition's status."""
-    update_data = {"status": AcquisitionStatus.ACQUIRED.value}
+    update_data = {"status": AcquisitionStatus.QC_PASSED.value}
     response = await async_client.patch(f"/api/v2/acquisitions/{test_acquisition.acquisition_id}", json=update_data)
     assert response.status_code == 200
     response_data = response.json()
-    assert response_data["status"] == AcquisitionStatus.ACQUIRED.value
+    assert response_data["status"] == AcquisitionStatus.QC_PASSED.value
     assert response_data["acquisition_id"] == test_acquisition.acquisition_id
     assert "end_time" not in update_data  # Ensure other fields weren't changed unless specified
 

--- a/tests/server/test_acquisition_task_api.py
+++ b/tests/server/test_acquisition_task_api.py
@@ -3,7 +3,13 @@ from datetime import datetime, timezone
 import pytest
 from httpx import AsyncClient
 
-from temdb.models import AcquisitionTaskStatus
+from temdb.models import AcquisitionStatus
+from temdb.server.documents import (
+    AcquisitionDocument,
+    AcquisitionTaskDocument,
+    ROIDocument,
+    SectionDocument,
+)
 
 
 @pytest.mark.asyncio
@@ -51,11 +57,145 @@ async def test_list_acquisition_tasks_filtered(
     assert len(res_spec_data) >= 1
     assert all(task["specimen_ref"]["id"] == str(test_specimen.id) for task in res_spec_data)
 
-    response_status = await async_client.get(f"/api/v2/acquisition-tasks?status={AcquisitionTaskStatus.PLANNED.value}")
-    assert response_status.status_code == 200
-    res_status_data = response_status.json()
-    assert isinstance(res_status_data, list)
-    assert all(task["status"] == AcquisitionTaskStatus.PLANNED.value for task in res_status_data)
+
+@pytest.mark.asyncio
+async def test_list_acquisition_tasks_skip_destroyed(
+    async_client: AsyncClient,
+    test_specimen,
+    test_block,
+    test_cutting_session,
+    test_substrate,
+    test_acquisition_task,
+):
+    destroyed_section = SectionDocument(
+        section_id="TEST_SECTION_DESTROYED_001",
+        section_number=2,
+        timestamp=datetime.now(timezone.utc),
+        cutting_session_id=test_cutting_session.cutting_session_id,
+        block_id=test_block.block_id,
+        specimen_id=test_specimen.specimen_id,
+        cutting_session_ref=test_cutting_session.id,
+        substrate_ref=test_substrate.id,
+        destroyed=True,
+        media_id="TEST_MEDIA_001",
+    )
+    await destroyed_section.insert()
+
+    destroyed_roi = ROIDocument(
+        roi_id="SPEC001.BLK001.CS001.SEC002.SUB001.ROI001",
+        roi_number=1,
+        section_id=destroyed_section.section_id,
+        block_id=test_block.block_id,
+        specimen_id=test_specimen.specimen_id,
+        substrate_media_id="SUB001",
+        hierarchy_level=1,
+        section_ref=destroyed_section.id,
+        parent_roi_ref=None,
+        updated_at=datetime.now(timezone.utc),
+        section_number=destroyed_section.section_number,
+    )
+    await destroyed_roi.insert()
+
+    destroyed_task = AcquisitionTaskDocument(
+        task_id="TEST_TASK_DESTROYED_001",
+        specimen_id=test_specimen.specimen_id,
+        block_id=test_block.block_id,
+        roi_id=destroyed_roi.roi_id,
+        specimen_ref=test_specimen.id,
+        block_ref=test_block.id,
+        roi_ref=destroyed_roi.id,
+        task_type="standard_acquisition",
+        version=1,
+        created_at=datetime.now(timezone.utc),
+    )
+    await destroyed_task.insert()
+
+    default_response = await async_client.get("/api/v2/acquisition-tasks")
+    assert default_response.status_code == 200
+    default_ids = {task["task_id"] for task in default_response.json()}
+    assert test_acquisition_task.task_id in default_ids
+    assert destroyed_task.task_id not in default_ids
+
+    include_response = await async_client.get("/api/v2/acquisition-tasks?skip_destroyed=false")
+    assert include_response.status_code == 200
+    include_ids = {task["task_id"] for task in include_response.json()}
+    assert destroyed_task.task_id in include_ids
+
+
+@pytest.mark.asyncio
+async def test_list_acquisition_tasks_skip_completed(
+    async_client: AsyncClient,
+    test_specimen,
+    test_block,
+    test_roi,
+    test_acquisition_task,
+):
+    pending_acquisition = AcquisitionDocument(
+        acquisition_id="TEST_ACQ_QC_PENDING_001",
+        montage_id="TEST_MONTAGE_QC_PENDING_001",
+        specimen_id=test_specimen.specimen_id,
+        roi_id=test_roi.roi_id,
+        acquisition_task_id=test_acquisition_task.task_id,
+        specimen_ref=test_specimen.id,
+        roi_ref=test_roi.id,
+        acquisition_task_ref=test_acquisition_task.id,
+        hardware_settings={
+            "scope_id": "TEST_SCOPE_001",
+            "camera_model": "Test Camera",
+            "camera_serial": "12345",
+            "camera_bit_depth": 16,
+            "media_type": "tape",
+        },
+        acquisition_settings={
+            "magnification": 1000,
+            "spot_size": 2,
+            "exposure_time": 100,
+            "tile_size": [4096, 4096],
+            "tile_overlap": 0.1,
+            "saved_bit_depth": 8,
+        },
+        status=AcquisitionStatus.QC_PENDING,
+        start_time=datetime.now(timezone.utc),
+    )
+    passed_acquisition = AcquisitionDocument(
+        acquisition_id="TEST_ACQ_QC_PASSED_001",
+        montage_id="TEST_MONTAGE_QC_PASSED_001",
+        specimen_id=test_specimen.specimen_id,
+        roi_id=test_roi.roi_id,
+        acquisition_task_id=test_acquisition_task.task_id,
+        specimen_ref=test_specimen.id,
+        roi_ref=test_roi.id,
+        acquisition_task_ref=test_acquisition_task.id,
+        hardware_settings={
+            "scope_id": "TEST_SCOPE_001",
+            "camera_model": "Test Camera",
+            "camera_serial": "12345",
+            "camera_bit_depth": 16,
+            "media_type": "tape",
+        },
+        acquisition_settings={
+            "magnification": 1000,
+            "spot_size": 2,
+            "exposure_time": 100,
+            "tile_size": [4096, 4096],
+            "tile_overlap": 0.1,
+            "saved_bit_depth": 8,
+        },
+        status=AcquisitionStatus.QC_PASSED,
+        start_time=datetime.now(timezone.utc),
+    )
+    await pending_acquisition.insert()
+    await passed_acquisition.insert()
+
+    default_response = await async_client.get("/api/v2/acquisition-tasks")
+    assert default_response.status_code == 200
+    default_ids = {task["task_id"] for task in default_response.json()}
+    assert test_acquisition_task.task_id not in default_ids
+
+    include_response = await async_client.get("/api/v2/acquisition-tasks?skip_completed=false")
+    assert include_response.status_code == 200
+    include_ids = {task["task_id"] for task in include_response.json()}
+    assert test_acquisition_task.task_id in include_ids
 
 
 @pytest.mark.asyncio
@@ -75,7 +215,6 @@ async def test_create_acquisition_task(async_client: AsyncClient, test_specimen,
     assert response.status_code == 201
     response_data = response.json()
     assert response_data["task_id"] == task_id_hr
-    assert response_data["status"] == AcquisitionTaskStatus.PLANNED.value
     assert response_data["specimen_ref"]["id"] == str(test_specimen.id)
     assert response_data["block_ref"]["id"] == str(test_block.id)
     assert response_data["roi_ref"]["id"] == str(test_roi.id)
@@ -124,15 +263,13 @@ async def test_get_acquisition_task_not_found(async_client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_update_acquisition_task(async_client: AsyncClient, test_acquisition_task):
-    """Test updating a task's status and metadata."""
+    """Test updating a task's metadata."""
     update_data = {
-        "status": AcquisitionTaskStatus.IN_PROGRESS.value,
         "metadata": {"updated_key": "updated_value"},
     }
     response = await async_client.patch(f"/api/v2/acquisition-tasks/{test_acquisition_task.task_id}", json=update_data)
     assert response.status_code == 200
     response_data = response.json()
-    assert response_data["status"] == AcquisitionTaskStatus.IN_PROGRESS.value
     assert response_data["metadata"]["updated_key"] == "updated_value"
     assert response_data["task_id"] == test_acquisition_task.task_id
     assert "updated_at" in response_data
@@ -183,21 +320,6 @@ async def test_delete_task(async_client: AsyncClient, test_specimen, test_block,
 
 
 @pytest.mark.asyncio
-async def test_update_task_status(async_client: AsyncClient, test_acquisition_task):
-    """Test updating task status via the dedicated endpoint."""
-    status_update = {"status": AcquisitionTaskStatus.COMPLETED.value}
-    response = await async_client.post(
-        f"/api/v2/acquisition-tasks/{test_acquisition_task.task_id}/status",
-        json=status_update,
-    )
-    assert response.status_code == 200
-    response_data = response.json()
-    assert response_data["status"] == AcquisitionTaskStatus.COMPLETED.value
-    assert response_data["task_id"] == test_acquisition_task.task_id
-    assert response_data["updated_at"] is not None
-
-
-@pytest.mark.asyncio
 async def test_create_tasks_batch(async_client: AsyncClient, test_specimen, test_block, test_roi):
     """Test creating multiple tasks in a batch."""
     task_id_1 = f"TASK_BATCH_1_{int(datetime.now(timezone.utc).timestamp())}"
@@ -226,7 +348,6 @@ async def test_create_tasks_batch(async_client: AsyncClient, test_specimen, test
     assert len(response_data) == 2
     assert response_data[0]["task_id"] == task_id_1
     assert response_data[1]["task_id"] == task_id_2
-    assert response_data[0]["status"] == AcquisitionTaskStatus.PLANNED.value
     assert response_data[1]["task_type"] == "alignment_task"
     assert response_data[0]["roi_ref"]["id"] == str(test_roi.id)
     assert response_data[1]["roi_ref"]["id"] == str(test_roi.id)

--- a/tests/server/test_acquisition_task_api.py
+++ b/tests/server/test_acquisition_task_api.py
@@ -130,7 +130,7 @@ async def test_list_acquisition_tasks_skip_completed(
     test_roi,
     test_acquisition_task,
 ):
-    pending_acquisition = AcquisitionDocument(
+    failed_acquisition = AcquisitionDocument(
         acquisition_id="TEST_ACQ_QC_PENDING_001",
         montage_id="TEST_MONTAGE_QC_PENDING_001",
         specimen_id=test_specimen.specimen_id,
@@ -154,7 +154,7 @@ async def test_list_acquisition_tasks_skip_completed(
             "tile_overlap": 0.1,
             "saved_bit_depth": 8,
         },
-        status=AcquisitionStatus.QC_PENDING,
+        status=AcquisitionStatus.QC_FAILED,
         start_time=datetime.now(timezone.utc),
     )
     passed_acquisition = AcquisitionDocument(
@@ -184,7 +184,7 @@ async def test_list_acquisition_tasks_skip_completed(
         status=AcquisitionStatus.QC_PASSED,
         start_time=datetime.now(timezone.utc),
     )
-    await pending_acquisition.insert()
+    await failed_acquisition.insert()
     await passed_acquisition.insert()
 
     default_response = await async_client.get("/api/v2/acquisition-tasks")


### PR DESCRIPTION
The following changes were made:

1. The acquisition task status was removed
2. A destroyed flag was added to the section model
3. The number of options in the acquisition status enumerator was reduced
4. When listing acquisition tasks, tasks which have completed (`QC_PENDING`, or `QC_PASSED`) acquisition can be filtered out
5. When listing acquisition tasks, tasks which are related to destroyed section can be filtered out