### PR TITLE
Adding a middleware to send tracebacks on server errors, if enabled

### DIFF
--- a/packages/temdb/src/temdb/server/config.py
+++ b/packages/temdb/src/temdb/server/config.py
@@ -42,4 +42,8 @@ def get_config():
     return DevConfig()
 
 
+def is_debug_traceback_enabled() -> bool:
+    return os.getenv("DEBUG", "").strip().lower() == "true"
+
+
 config = get_config()

--- a/packages/temdb/src/temdb/server/exception_handlers.py
+++ b/packages/temdb/src/temdb/server/exception_handlers.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from pymongo.errors import DuplicateKeyError
 
 from temdb.models import APIErrorResponse
+from temdb.server.config import is_debug_traceback_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +113,8 @@ async def business_logic_exception_handler(request: Request, exc: BaseError):
 async def generic_exception_handler(request: Request, exc: Exception):
     """Handles any other unexpected exceptions (returns 500 Internal Server Error)."""
     logger.exception(f"Unhandled exception during request to {request.url}", exc_info=exc)
+    if is_debug_traceback_enabled():
+        raise exc
 
     error_content = APIErrorResponse(
         detail="An unexpected internal server error occurred. Please contact the administrator.",

--- a/packages/temdb/src/temdb/server/main.py
+++ b/packages/temdb/src/temdb/server/main.py
@@ -1,10 +1,12 @@
 import gzip
 import logging
+import traceback
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from temdb.server.api.v1.grids import grid_api
@@ -17,7 +19,7 @@ from temdb.server.api.v2.section import section_api
 from temdb.server.api.v2.specimen import specimen_api
 from temdb.server.api.v2.substrate import substrate_api
 from temdb.server.api.v2.tasks import acquisition_task_api
-from temdb.server.config import config
+from temdb.server.config import config, is_debug_traceback_enabled
 from temdb.server.database import DatabaseManager
 from temdb.server.exception_handlers import register_exception_handlers
 
@@ -65,6 +67,34 @@ class GzipRequestMiddleware:
             await self.app(scope, receive, send)
 
 
+class DebugTracebackMiddleware:
+    def __init__(self, app: ASGIApp, enabled: bool = False) -> None:
+        self.app = app
+        self.enabled = enabled
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            await self.app(scope, receive, send)
+        except Exception as exc:
+            if not self.enabled:
+                raise
+
+            traceback_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+            response = JSONResponse(
+                status_code=500,
+                content={
+                    "detail": str(exc) or "Unhandled server exception.",
+                    "error_code": "INTERNAL_SERVER_ERROR",
+                    "context": {"traceback": traceback_text},
+                },
+            )
+            await response(scope, receive, send)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     mongodb_uri = app.state.mongodb_uri
@@ -85,6 +115,7 @@ def create_app():
     )
     app.add_middleware(GzipRequestMiddleware)
     app.add_middleware(GZipMiddleware, minimum_size=1000)
+    app.add_middleware(DebugTracebackMiddleware, enabled=is_debug_traceback_enabled())
     app.config = config
     logging.info(f"Mongo URI: {app.config.mongodb_uri}")
     logging.info(f"Database name: {app.config.mongodb_name}")

--- a/tests/test_debug_traceback_middleware.py
+++ b/tests/test_debug_traceback_middleware.py
@@ -1,0 +1,50 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from temdb.server.main import create_app
+
+
+@pytest.mark.asyncio
+async def test_debug_true_returns_traceback(monkeypatch):
+    monkeypatch.setenv("DEBUG", "true")
+    app = create_app()
+
+    @app.get("/_raise")
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/_raise")
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["detail"] == "boom"
+    assert payload["error_code"] == "INTERNAL_SERVER_ERROR"
+    assert "context" in payload
+    assert "traceback" in payload["context"]
+    assert "RuntimeError: boom" in payload["context"]["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_debug_false_hides_traceback(monkeypatch):
+    monkeypatch.delenv("DEBUG", raising=False)
+    app = create_app()
+
+    @app.get("/_raise")
+    async def raise_error():
+        raise RuntimeError("boom")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/_raise")
+
+    assert response.status_code == 500
+    payload = response.json()
+    assert payload["detail"] == "An unexpected internal server error occurred. Please contact the administrator."
+    assert payload["error_code"] == "INTERNAL_SERVER_ERROR"
+    assert payload.get("context") is None


### PR DESCRIPTION
In order to ease debugging, add a middleware that can be enabled to return tracebacks when the server encounters an error.